### PR TITLE
Add endpoint settings

### DIFF
--- a/docker/dev.env
+++ b/docker/dev.env
@@ -6,4 +6,3 @@ RESULTSDB_TEST_URL=http://resultsdb:5001/
 PYTEST_ADDOPTS=-o cache_dir=/home/dev/.pytest_cache
 PYTHONPATH=/src
 GREENWAVE_STATSD_HOST=statsd:9125
-OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318/

--- a/docker/greenwave-settings.py
+++ b/docker/greenwave-settings.py
@@ -58,3 +58,7 @@ LOGGING = {
         'handlers': ['console'],
     },
 }
+
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = 'http://jaeger:4318/v1/traces'
+OTEL_EXPORTER_SERVICE_NAME = "greenwave"
+

--- a/greenwave/config.py
+++ b/greenwave/config.py
@@ -88,6 +88,9 @@ class Config(object):
         "ca_certs": "/etc/pki/umb/umb-ca",
     }
 
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = None
+    OTEL_EXPORTER_SERVICE_NAME = "greenwave"
+
 
 class ProductionConfig(Config):
     DEBUG = False


### PR DESCRIPTION
- Added selectable endpoints for trace data based on the Flask settings.py file.  
- Replaced the env variable for the dev environment to match the expected deployments.   
- Makes tracing a no-op if required settings are not specified. 
- Service name becomes a configuration item; potentially future-proofing.